### PR TITLE
Publish to @watchduty/camera Package

### DIFF
--- a/camera/WatchdutyCamera.podspec
+++ b/camera/WatchdutyCamera.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorCamera'
+  s.name = 'WatchdutyCamera'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/camera/ios/Plugin/CLLocationExtensions.swift
+++ b/camera/ios/Plugin/CLLocationExtensions.swift
@@ -7,7 +7,7 @@ import CoreLocation
 import ImageIO
 
 extension CLLocation {
-    
+
     func exifMetadata(heading: CLHeading? = nil) -> NSMutableDictionary {
 
         let GPSMetadata = NSMutableDictionary()
@@ -36,14 +36,14 @@ extension CLLocation {
 }
 
 extension Date {
-    
+
     func isoDate() -> String {
         let f = DateFormatter()
         f.timeZone = TimeZone(abbreviation: "UTC")
         f.dateFormat = "yyyy:MM:dd"
         return f.string(from: self)
     }
-    
+
     func isoTime() -> String {
         let f = DateFormatter()
         f.timeZone = TimeZone(abbreviation: "UTC")

--- a/camera/ios/Plugin/CameraPlugin.swift
+++ b/camera/ios/Plugin/CameraPlugin.swift
@@ -223,7 +223,7 @@ private extension CameraPlugin {
     }
 
     func showPrompt() {
-        Locator.shared.authorize();
+        Locator.shared.authorize()
         Locator.shared.getLocation { result in
             print("Location Result: \(String(describing: result))")
             switch result {
@@ -235,7 +235,7 @@ private extension CameraPlugin {
                     print(error)
             }
          }
-        
+
         Locator.shared.getHeading { result in
             print("Heading Result: \(String(describing: result))")
             switch result {
@@ -411,7 +411,7 @@ private extension CameraPlugin {
         metadata[kCGImagePropertyGPSDictionary as String] = self.currentLocation.exifMetadata(heading: self.currentHeading)
 
         print("Meta Data: \(String(describing: metadata))")
-        
+
         // get the result
         let result = processedImage(from: image, with: metadata)
         // conditionally save the image

--- a/camera/ios/Plugin/Locator.swift
+++ b/camera/ios/Plugin/Locator.swift
@@ -13,14 +13,14 @@ class Locator: NSObject, CLLocationManagerDelegate {
 
     typealias Callback = (Result <Locator>) -> Void
 
-    var locationRequests: Array <Callback> = Array <Callback>()
-    var headingRequests: Array <Callback> = Array <Callback>()
+    var locationRequests:  [Callback] =  [Callback]()
+    var headingRequests:  [Callback] =  [Callback]()
 
     var location: CLLocation? { return sharedLocationManager.location }
     var heading: CLHeading? { return sharedLocationManager.heading }
     var headingCnt: Int = 0
     var locationCnt: Int = 0
-        
+
     lazy var sharedLocationManager: CLLocationManager = {
         let newLocationmanager = CLLocationManager()
         newLocationmanager.delegate = self
@@ -50,9 +50,9 @@ class Locator: NSObject, CLLocationManagerDelegate {
             print("Trying to get Location!!")
         }
     }
-    
+
     func getHeading(callback: @escaping Callback) {
-        if (CLLocationManager.headingAvailable()) {
+        if CLLocationManager.headingAvailable() {
             self.headingRequests.append(callback)
             sharedLocationManager.headingFilter = 1
             sharedLocationManager.startUpdatingHeading()
@@ -61,12 +61,12 @@ class Locator: NSObject, CLLocationManagerDelegate {
     }
 
     func resetLocation() {
-        self.locationRequests = Array <Callback>()
+        self.locationRequests =  [Callback]()
         sharedLocationManager.stopUpdatingLocation()
     }
-    
+
     func resetHeading() {
-        self.headingRequests = Array <Callback>()
+        self.headingRequests =  [Callback]()
         sharedLocationManager.stopUpdatingHeading()
     }
 
@@ -82,25 +82,25 @@ class Locator: NSObject, CLLocationManagerDelegate {
         print("Location Result: \(String(describing: self.location))")
         for request in self.locationRequests { request(.Success(self))}
 
-        if (locationCnt < 4) {
+        if locationCnt < 4 {
             locationCnt += 1
             return
         }
         locationCnt = 0
-        
+
         self.resetLocation()
     }
-   
+
     func  locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         print("Heading Result: \(String(describing: heading))")
         for request in self.headingRequests { request(.Success(self))}
 
-        if (headingCnt < 4) {
+        if headingCnt < 4 {
             headingCnt += 1
             return
         }
         headingCnt = 0
-        
+
         self.resetHeading()
     }
 }

--- a/camera/package.json
+++ b/camera/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@watchduty/camera",
-  "version": "1.0.3",
+  "version": "1.0.3-wd3",
   "description": "The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.",
   "main": "dist/plugin.cjs.js",
   "module": "dist/esm/index.js",

--- a/camera/package.json
+++ b/camera/package.json
@@ -11,7 +11,7 @@
     "android/build.gradle",
     "dist/",
     "ios/Plugin/",
-    "CapacitorCamera.podspec"
+    "WatchdutyCamera.podspec"
   ],
   "author": "Ionic <hi@ionicframework.com>",
   "license": "MIT",

--- a/camera/package.json
+++ b/camera/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capacitor/camera",
+  "name": "@watchduty/camera",
   "version": "1.0.3",
   "description": "The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.",
   "main": "dist/plugin.cjs.js",

--- a/camera/rollup.config.js
+++ b/camera/rollup.config.js
@@ -4,7 +4,7 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorCamera',
+      name: 'WatchdutyCamera',
       globals: {
         '@capacitor/core': 'capacitorExports',
       },


### PR DESCRIPTION
This renames the Camera plugin to be `@watchduty/camera` for our fork. SwiftLint was also failing, so I fixed errors with `npm run swiftlint autocorrect`.

To publish a new version:

1. `npm install`
2. `cd camera`
3. `npm install`
4. `npm version <new version number>` (I used the current upstream version + `-wdN` where `N` is the Nth update on our fork. We can of course change this.)
5. `npm publish`

Note: I'm happy to rename the NPM organization if desired. I also considered using Github to host the package, but the advantages there seem mostly around private packages on larger teams. Publishing via NPM should just work for everyone.)