### PR TITLE
Fix Podspec Repo URL

### DIFF
--- a/camera/WatchdutyCamera.podspec
+++ b/camera/WatchdutyCamera.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license = package['license']
   s.homepage = 'https://capacitorjs.com'
   s.author = package['author']
-  s.source = { :git => 'https://github.com/ionic-team/capacitor-plugins.git', :tag => package['name'] + '@' + package['version'] }
+  s.source = { :git => 'https://github.com/sherwood-forestry-service/capacitor-plugins.git', :tag => package['name'] + '@' + package['version'] }
   s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}', 'camera/ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'

--- a/camera/package.json
+++ b/camera/package.json
@@ -42,7 +42,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "publish:cocoapod": "pod trunk push ./CapacitorCamera.podspec --allow-warnings"
+    "publish:cocoapod": "pod trunk push ./WatchdutyCamera.podspec --allow-warnings"
   },
   "devDependencies": {
     "@capacitor/android": "^4.0.0",


### PR DESCRIPTION
I noticed that our fork of Capacitor Camera still points to the the original repository as the Podfile source. This fixes that.