### PR TITLE
Capacitor 6

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,4 @@
 package-lock=false
-provenance=true
+# disable provenance for now since we only publish occasionally locally
+# and we are a fork not intended for mass adoption ourside of Watch Duty
+provenance=false

--- a/camera/WatchdutyCamera.podspec
+++ b/camera/WatchdutyCamera.podspec
@@ -3,7 +3,7 @@ require 'json'
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 
 Pod::Spec.new do |s|
-  s.name = 'CapacitorCamera'
+  s.name = 'WatchdutyCamera'
   s.version = package['version']
   s.summary = package['description']
   s.license = package['license']

--- a/camera/WatchdutyCamera.podspec
+++ b/camera/WatchdutyCamera.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.license = package['license']
   s.homepage = 'https://capacitorjs.com'
   s.author = package['author']
-  s.source = { :git => 'https://github.com/ionic-team/capacitor-plugins.git', :tag => package['name'] + '@' + package['version'] }
+  s.source = { :git => 'https://github.com/sherwood-forestry-service/capacitor-plugins.git', :tag => package['name'] + '@' + package['version'] }
   s.source_files = 'ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}', 'camera/ios/Sources/**/*.{swift,h,m,c,cc,mm,cpp}'
   s.ios.deployment_target  = '13.0'
   s.dependency 'Capacitor'

--- a/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
+++ b/camera/android/src/main/java/com/capacitorjs/plugins/camera/ExifWrapper.java
@@ -65,10 +65,10 @@ public class ExifWrapper {
         TAG_GPS_H_POSITIONING_ERROR,
         TAG_GPS_IMG_DIRECTION,
         TAG_GPS_IMG_DIRECTION_REF,
-        TAG_GPS_LATITUDE,
-        TAG_GPS_LATITUDE_REF,
-        TAG_GPS_LONGITUDE,
-        TAG_GPS_LONGITUDE_REF,
+        // TAG_GPS_LATITUDE,          // Added manually in toJson()
+        // TAG_GPS_LATITUDE_REF,      // Not needed: values are signed
+        // TAG_GPS_LONGITUDE,         // Added manually in toJson()
+        // TAG_GPS_LONGITUDE_REF,     // Not needed: values are signed
         TAG_GPS_MAP_DATUM,
         TAG_GPS_MEASURE_MODE,
         TAG_GPS_PROCESSING_METHOD,
@@ -176,6 +176,14 @@ public class ExifWrapper {
 
         for (int i = 0; i < attributes.length; i++) {
             p(ret, attributes[i]);
+        }
+
+        // Manually add the latitude and longitude values. Values from getLatLong() are
+        // returned as signed DD.
+        double[] latlong = exif.getLatLong();
+        if (latlong != null) {
+            ret.put(TAG_GPS_LATITUDE, String.valueOf(latlong[0]));
+            ret.put(TAG_GPS_LONGITUDE, String.valueOf(latlong[1]));
         }
 
         return ret;

--- a/camera/ios/Sources/CameraPlugin/CLLocationExtensions.swift
+++ b/camera/ios/Sources/CameraPlugin/CLLocationExtensions.swift
@@ -1,0 +1,53 @@
+// https://gist.github.com/nitrag/343fe13f01bb0ef3692f2ae2dfe33e86
+// Generate EXIF GPS metadata
+// Swift 3
+// Exif Version 2.2.0.0 supports decimal degrees
+import Foundation
+import CoreLocation
+import ImageIO
+
+extension CLLocation {
+    
+    func exifMetadata(heading: CLHeading? = nil) -> NSMutableDictionary {
+
+        let GPSMetadata = NSMutableDictionary()
+        let altitudeRef = Int(self.altitude < 0.0 ? 1 : 0)
+        let latitudeRef = self.coordinate.latitude < 0.0 ? "S" : "N"
+        let longitudeRef = self.coordinate.longitude < 0.0 ? "W" : "E"
+
+        // GPS metadata
+        GPSMetadata[(kCGImagePropertyGPSLatitude as String)] = abs(self.coordinate.latitude)
+        GPSMetadata[(kCGImagePropertyGPSLongitude as String)] = abs(self.coordinate.longitude)
+        GPSMetadata[(kCGImagePropertyGPSLatitudeRef as String)] = latitudeRef
+        GPSMetadata[(kCGImagePropertyGPSLongitudeRef as String)] = longitudeRef
+        GPSMetadata[(kCGImagePropertyGPSAltitude as String)] = Int(abs(self.altitude))
+        GPSMetadata[(kCGImagePropertyGPSAltitudeRef as String)] = altitudeRef
+        GPSMetadata[(kCGImagePropertyGPSTimeStamp as String)] = self.timestamp.isoTime()
+        GPSMetadata[(kCGImagePropertyGPSDateStamp as String)] = self.timestamp.isoDate()
+        GPSMetadata[(kCGImagePropertyGPSVersion as String)] = "2.2.0.0"
+
+        if let heading = heading {
+            GPSMetadata[(kCGImagePropertyGPSImgDirection as String)] = heading.trueHeading
+            GPSMetadata[(kCGImagePropertyGPSImgDirectionRef as String)] = "T"
+        }
+
+        return GPSMetadata
+    }
+}
+
+extension Date {
+    
+    func isoDate() -> String {
+        let f = DateFormatter()
+        f.timeZone = TimeZone(abbreviation: "UTC")
+        f.dateFormat = "yyyy:MM:dd"
+        return f.string(from: self)
+    }
+    
+    func isoTime() -> String {
+        let f = DateFormatter()
+        f.timeZone = TimeZone(abbreviation: "UTC")
+        f.dateFormat = "HH:mm:ss.SSSSSS"
+        return f.string(from: self)
+    }
+}

--- a/camera/ios/Sources/CameraPlugin/CLLocationExtensions.swift
+++ b/camera/ios/Sources/CameraPlugin/CLLocationExtensions.swift
@@ -7,7 +7,7 @@ import CoreLocation
 import ImageIO
 
 extension CLLocation {
-    
+
     func exifMetadata(heading: CLHeading? = nil) -> NSMutableDictionary {
 
         let GPSMetadata = NSMutableDictionary()
@@ -36,14 +36,14 @@ extension CLLocation {
 }
 
 extension Date {
-    
+
     func isoDate() -> String {
         let f = DateFormatter()
         f.timeZone = TimeZone(abbreviation: "UTC")
         f.dateFormat = "yyyy:MM:dd"
         return f.string(from: self)
     }
-    
+
     func isoTime() -> String {
         let f = DateFormatter()
         f.timeZone = TimeZone(abbreviation: "UTC")

--- a/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
+++ b/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
@@ -21,8 +21,8 @@ public class CameraPlugin: CAPPlugin, CAPBridgedPlugin {
     private let defaultDirection = CameraDirection.rear
     private var multiple = false
 
-    private var currentLocation = CLLocation()
-    private var currentHeading = CLHeading()
+    private var currentLocation: CLLocation? = nil
+    private var currentHeading: CLHeading? = nil
 
     private var imageCounter = 0
 
@@ -407,6 +407,24 @@ private extension CameraPlugin {
     }
 
     func showPrompt() {
+        // Build the action sheet
+        let alert = UIAlertController(title: settings.userPromptText.title, message: nil, preferredStyle: UIAlertController.Style.actionSheet)
+        alert.addAction(UIAlertAction(title: settings.userPromptText.photoAction, style: .default, handler: { [weak self] (_: UIAlertAction) in
+            self?.showPhotos()
+        }))
+
+        alert.addAction(UIAlertAction(title: settings.userPromptText.cameraAction, style: .default, handler: { [weak self] (_: UIAlertAction) in
+            self?.showCamera()
+        }))
+
+        alert.addAction(UIAlertAction(title: settings.userPromptText.cancelAction, style: .cancel, handler: { [weak self] (_: UIAlertAction) in
+            self?.call?.reject("User cancelled photos app")
+        }))
+        self.setCenteredPopover(alert)
+        self.bridge?.viewController?.present(alert, animated: true, completion: nil)
+    }
+
+    func showCamera() {
         Locator.shared.authorize()
         Locator.shared.getLocation { result in
             print("Location Result: \(String(describing: result))")
@@ -430,26 +448,8 @@ private extension CameraPlugin {
                 case Locator.Result.Failure(let error):
                     print(error)
             }
-         }
+        }
 
-        // Build the action sheet
-        let alert = UIAlertController(title: settings.userPromptText.title, message: nil, preferredStyle: UIAlertController.Style.actionSheet)
-        alert.addAction(UIAlertAction(title: settings.userPromptText.photoAction, style: .default, handler: { [weak self] (_: UIAlertAction) in
-            self?.showPhotos()
-        }))
-
-        alert.addAction(UIAlertAction(title: settings.userPromptText.cameraAction, style: .default, handler: { [weak self] (_: UIAlertAction) in
-            self?.showCamera()
-        }))
-
-        alert.addAction(UIAlertAction(title: settings.userPromptText.cancelAction, style: .cancel, handler: { [weak self] (_: UIAlertAction) in
-            self?.call?.reject("User cancelled photos app")
-        }))
-        self.setCenteredPopover(alert)
-        self.bridge?.viewController?.present(alert, animated: true, completion: nil)
-    }
-
-    func showCamera() {
         // check if we have a camera
         if (bridge?.isSimEnvironment ?? false) || !UIImagePickerController.isSourceTypeAvailable(UIImagePickerController.SourceType.camera) {
             CAPLog.print("⚡️ ", self.pluginId, "-", "Camera not available in simulator")
@@ -591,7 +591,9 @@ private extension CameraPlugin {
             metadata = asset.imageData
         }
 
-        metadata[kCGImagePropertyGPSDictionary as String] = self.currentLocation.exifMetadata(heading: self.currentHeading)
+        if let currentLocation = self.currentLocation {
+            metadata[kCGImagePropertyGPSDictionary as String] = currentLocation.exifMetadata(heading: self.currentHeading)
+        }
 
         print("Meta Data: \(String(describing: metadata))")
 

--- a/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
+++ b/camera/ios/Sources/CameraPlugin/CameraPlugin.swift
@@ -407,7 +407,7 @@ private extension CameraPlugin {
     }
 
     func showPrompt() {
-        Locator.shared.authorize();
+        Locator.shared.authorize()
         Locator.shared.getLocation { result in
             print("Location Result: \(String(describing: result))")
             switch result {
@@ -419,7 +419,7 @@ private extension CameraPlugin {
                     print(error)
             }
          }
-        
+
         Locator.shared.getHeading { result in
             print("Heading Result: \(String(describing: result))")
             switch result {
@@ -594,7 +594,7 @@ private extension CameraPlugin {
         metadata[kCGImagePropertyGPSDictionary as String] = self.currentLocation.exifMetadata(heading: self.currentHeading)
 
         print("Meta Data: \(String(describing: metadata))")
-        
+
         // get the result
         var result = processedImage(from: image, with: metadata)
         result.flags = flags

--- a/camera/ios/Sources/CameraPlugin/Locator.swift
+++ b/camera/ios/Sources/CameraPlugin/Locator.swift
@@ -1,0 +1,106 @@
+import CoreLocation
+
+// https://stackoverflow.com/a/32832351
+// https://github.com/heckj/swiftui-notes/blob/master/SwiftUI-Notes/LocationModelProxy.swift
+// https://www.advancedswift.com/user-location-in-swift/
+class Locator: NSObject, CLLocationManagerDelegate {
+    enum Result <T> {
+      case Success(T)
+      case Failure(Error)
+    }
+
+    static let shared: Locator = Locator()
+
+    typealias Callback = (Result <Locator>) -> Void
+
+    var locationRequests: Array <Callback> = Array <Callback>()
+    var headingRequests: Array <Callback> = Array <Callback>()
+
+    var location: CLLocation? { return sharedLocationManager.location }
+    var heading: CLHeading? { return sharedLocationManager.heading }
+    var headingCnt: Int = 0
+    var locationCnt: Int = 0
+        
+    lazy var sharedLocationManager: CLLocationManager = {
+        let newLocationmanager = CLLocationManager()
+        newLocationmanager.delegate = self
+        newLocationmanager.desiredAccuracy = kCLLocationAccuracyBestForNavigation
+        // ...
+        print("sharedLocationManager!!")
+        return newLocationmanager
+    }()
+
+    // MARK: - Authorization
+
+    class func authorize() { shared.authorize() }
+    func authorize() { sharedLocationManager.requestWhenInUseAuthorization()
+        print("Trying to authorize!!")
+
+    }
+
+    // MARK: - Helpers
+
+    func getLocation(callback: @escaping Callback) {
+        if CLLocationManager.authorizationStatus() == .notDetermined {
+            sharedLocationManager.requestWhenInUseAuthorization()
+        } else {
+            sharedLocationManager.startUpdatingLocation()
+            self.locationRequests.append(callback)
+            sharedLocationManager.startUpdatingLocation()
+            print("Trying to get Location!!")
+        }
+    }
+    
+    func getHeading(callback: @escaping Callback) {
+        if (CLLocationManager.headingAvailable()) {
+            self.headingRequests.append(callback)
+            sharedLocationManager.headingFilter = 1
+            sharedLocationManager.startUpdatingHeading()
+            print("Trying to get Heading!!")
+        }
+    }
+
+    func resetLocation() {
+        self.locationRequests = Array <Callback>()
+        sharedLocationManager.stopUpdatingLocation()
+    }
+    
+    func resetHeading() {
+        self.headingRequests = Array <Callback>()
+        sharedLocationManager.stopUpdatingHeading()
+    }
+
+    // MARK: - Delegate
+
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        print("Location Error: \(String(describing: error))")
+        for request in self.locationRequests { request(.Failure(error)) }
+        self.resetLocation()
+    }
+
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        print("Location Result: \(String(describing: self.location))")
+        for request in self.locationRequests { request(.Success(self))}
+
+        if (locationCnt < 4) {
+            locationCnt += 1
+            return
+        }
+        locationCnt = 0
+        
+        self.resetLocation()
+    }
+   
+    func  locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
+        print("Heading Result: \(String(describing: heading))")
+        for request in self.headingRequests { request(.Success(self))}
+
+        if (headingCnt < 4) {
+            headingCnt += 1
+            return
+        }
+        headingCnt = 0
+        
+        self.resetHeading()
+    }
+}

--- a/camera/ios/Sources/CameraPlugin/Locator.swift
+++ b/camera/ios/Sources/CameraPlugin/Locator.swift
@@ -13,14 +13,14 @@ class Locator: NSObject, CLLocationManagerDelegate {
 
     typealias Callback = (Result <Locator>) -> Void
 
-    var locationRequests: Array <Callback> = Array <Callback>()
-    var headingRequests: Array <Callback> = Array <Callback>()
+    var locationRequests:  [Callback] =  [Callback]()
+    var headingRequests:  [Callback] =  [Callback]()
 
     var location: CLLocation? { return sharedLocationManager.location }
     var heading: CLHeading? { return sharedLocationManager.heading }
     var headingCnt: Int = 0
     var locationCnt: Int = 0
-        
+
     lazy var sharedLocationManager: CLLocationManager = {
         let newLocationmanager = CLLocationManager()
         newLocationmanager.delegate = self
@@ -50,9 +50,9 @@ class Locator: NSObject, CLLocationManagerDelegate {
             print("Trying to get Location!!")
         }
     }
-    
+
     func getHeading(callback: @escaping Callback) {
-        if (CLLocationManager.headingAvailable()) {
+        if CLLocationManager.headingAvailable() {
             self.headingRequests.append(callback)
             sharedLocationManager.headingFilter = 1
             sharedLocationManager.startUpdatingHeading()
@@ -61,12 +61,12 @@ class Locator: NSObject, CLLocationManagerDelegate {
     }
 
     func resetLocation() {
-        self.locationRequests = Array <Callback>()
+        self.locationRequests =  [Callback]()
         sharedLocationManager.stopUpdatingLocation()
     }
-    
+
     func resetHeading() {
-        self.headingRequests = Array <Callback>()
+        self.headingRequests =  [Callback]()
         sharedLocationManager.stopUpdatingHeading()
     }
 
@@ -82,25 +82,25 @@ class Locator: NSObject, CLLocationManagerDelegate {
         print("Location Result: \(String(describing: self.location))")
         for request in self.locationRequests { request(.Success(self))}
 
-        if (locationCnt < 4) {
+        if locationCnt < 4 {
             locationCnt += 1
             return
         }
         locationCnt = 0
-        
+
         self.resetLocation()
     }
-   
+
     func  locationManager(_ manager: CLLocationManager, didUpdateHeading newHeading: CLHeading) {
         print("Heading Result: \(String(describing: heading))")
         for request in self.headingRequests { request(.Success(self))}
 
-        if (headingCnt < 4) {
+        if headingCnt < 4 {
             headingCnt += 1
             return
         }
         headingCnt = 0
-        
+
         self.resetHeading()
     }
 }

--- a/camera/package.json
+++ b/camera/package.json
@@ -13,7 +13,7 @@
     "ios/Sources",
     "ios/Tests",
     "Package.swift",
-    "CapacitorCamera.podspec"
+    "WatchdutyCamera.podspec"
   ],
   "author": "Ionic <hi@ionicframework.com>",
   "license": "MIT",

--- a/camera/package.json
+++ b/camera/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@capacitor/camera",
+  "name": "@watchduty/camera",
   "version": "6.0.2",
   "description": "The Camera API provides the ability to take a photo with the camera or choose an existing one from the photo album.",
   "main": "dist/plugin.cjs.js",
@@ -44,7 +44,7 @@
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",
-    "publish:cocoapod": "pod trunk push ./CapacitorCamera.podspec --allow-warnings"
+    "publish:cocoapod": "pod trunk push ./WatchdutyCamera.podspec --allow-warnings"
   },
   "devDependencies": {
     "@capacitor/android": "^6.0.0",

--- a/camera/rollup.config.js
+++ b/camera/rollup.config.js
@@ -4,7 +4,7 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'capacitorCamera',
+      name: 'WatchdutyCamera',
       globals: {
         '@capacitor/core': 'capacitorExports',
       },

--- a/camera/rollup.config.js
+++ b/camera/rollup.config.js
@@ -4,7 +4,7 @@ export default {
     {
       file: 'dist/plugin.js',
       format: 'iife',
-      name: 'WatchdutyCamera',
+      name: 'watchdutyCamera',
       globals: {
         '@capacitor/core': 'capacitorExports',
       },


### PR DESCRIPTION
This rebases our forked changes onto the `6.x` branch to support Capacitor 6. I chose to rebase/cherry-pick our changes rather than merge so that all our changes are within the same set of commits and it's easier to see what we've actually changed (and to avoid unrelated merge conflicts). I took the liberty to squash a few related commits that were made outside of Pull Requests.

> [!IMPORTANT]
> To be clear, there should be no new changes in this PR that weren't already authored by Watch Duty in `main` or by the Ionic team upstream.

### Branching Strategy

With this change, I'm proposing changes to the way that we manage this fork. Before, we would merge the latest upstream stable branch (previously `5.x`) into our `main` branch and release from there. This resulted in several unrelated merge conflicts when attempting to merge `6.x` into `main`. Instead, I propose we follow the branching strategy of the upstream Ionic repo:

- Our `5.x` branch contains our changes on top of the upstream `5.x` branch. I've already cherry-picked our commits onto this branch, and there's no diff with `main`.
- Our `6.x` branch (with this PR) will similarly contain our changes on top of the upstream `6.x` branch. When new versions of Capacitor 6 are released, we'll `git merge` the upstream `6.x` branch into this.
- `main` will be hard reset against the upstream `main` branch to remove any difference between the two initially. If/when we decide to formalize our internal changes into PRs that Capacitor might accept, we can branch off `main` and submit changes from feature branches.
    - Just to be safe, I've already created a backup of `main` called `main-bkp-cap-5`. We probably won't need to keep this long-term, especially since `main` has no diff against `5.x` currently.
- When Capacitor 7 comes out, we'll cherry-pick our changes from the `6.x` branch onto the `7.x` branch.

Please let me know how this sounds. Hopefully, we will shrink the delta between our fork and upstream over time!